### PR TITLE
Update bokehpivot to be compatible with latest bokeh and fix bugs

### DIFF
--- a/bokehpivot/reeds2.py
+++ b/bokehpivot/reeds2.py
@@ -15,9 +15,8 @@ import numpy as np
 import collections
 import core
 
-rb_globs = {'output_subdir':'\\outputs\\', 'test_file':'cap.csv', 'report_subdir':'/reeds2'}
+rb_globs = {'output_subdir':'/outputs/', 'test_file':'cap.csv', 'report_subdir':'/reeds2'}
 this_dir_path = os.path.dirname(os.path.realpath(__file__))
-CRF_reeds = 0.077
 df_deflator = pd.read_csv(this_dir_path + '/in/inflation.csv', index_col=0)
 costs_orig_inv = ['Capital no ITC']
 costs_pol_inv = ['Capital','PTC','Emissions Tax']

--- a/bokehpivot/reeds_bokeh.py
+++ b/bokehpivot/reeds_bokeh.py
@@ -145,20 +145,20 @@ def get_wdg_reeds(path, init_load, wdg_config, wdg_defaults, custom_sorts, custo
 
     #Model Variables
     topwdg['reeds_vars'] = bmw.Div(text='Model Variables', css_classes=['reeds-vars-dropdown'])
-    topwdg['var_dollar_year'] = bmw.TextInput(title='Dollar Year', value=str(DEFAULT_DOLLAR_YEAR), css_classes=['wdgkey-dollar_year', 'reeds-vars-drop'])
-    topwdg['var_discount_rate'] = bmw.TextInput(title='Discount Rate', value=str(DEFAULT_DISCOUNT_RATE), css_classes=['wdgkey-discount_rate', 'reeds-vars-drop'])
-    topwdg['var_pv_year'] = bmw.TextInput(title='Present Value Reference Year', value=str(DEFAULT_PV_YEAR), css_classes=['wdgkey-pv_year', 'reeds-vars-drop'])
-    topwdg['var_end_year'] = bmw.TextInput(title='Present Value End Year', value=str(DEFAULT_END_YEAR), css_classes=['wdgkey-end_year', 'reeds-vars-drop'])
+    topwdg['var_dollar_year'] = bmw.TextInput(title='Dollar Year', value=str(DEFAULT_DOLLAR_YEAR), css_classes=['wdgkey-dollar_year', 'reeds-vars-drop'], visible=False)
+    topwdg['var_discount_rate'] = bmw.TextInput(title='Discount Rate', value=str(DEFAULT_DISCOUNT_RATE), css_classes=['wdgkey-discount_rate', 'reeds-vars-drop'], visible=False)
+    topwdg['var_pv_year'] = bmw.TextInput(title='Present Value Reference Year', value=str(DEFAULT_PV_YEAR), css_classes=['wdgkey-pv_year', 'reeds-vars-drop'], visible=False)
+    topwdg['var_end_year'] = bmw.TextInput(title='Present Value End Year', value=str(DEFAULT_END_YEAR), css_classes=['wdgkey-end_year', 'reeds-vars-drop'], visible=False)
 
     #Meta widgets
     topwdg['meta'] = bmw.Div(text='Meta', css_classes=['meta-dropdown'])
     for col in reeds.columns_meta:
         if 'map' in reeds.columns_meta[col]:
-            topwdg['meta_map_'+col] = bmw.TextInput(title='"'+col+ '" Map', value=reeds.columns_meta[col]['map'], css_classes=['wdgkey-meta_map_'+col, 'meta-drop'])
+            topwdg['meta_map_'+col] = bmw.TextInput(title='"'+col+ '" Map', value=reeds.columns_meta[col]['map'], css_classes=['wdgkey-meta_map_'+col, 'meta-drop'], visible=False)
         if 'join' in reeds.columns_meta[col]:
-            topwdg['meta_join_'+col] = bmw.TextInput(title='"'+col+ '" Join', value=reeds.columns_meta[col]['join'], css_classes=['wdgkey-meta_join_'+col, 'meta-drop'])
+            topwdg['meta_join_'+col] = bmw.TextInput(title='"'+col+ '" Join', value=reeds.columns_meta[col]['join'], css_classes=['wdgkey-meta_join_'+col, 'meta-drop'], visible=False)
         if 'style' in reeds.columns_meta[col]:
-            topwdg['meta_style_'+col] = bmw.TextInput(title='"'+col+ '" Style', value=reeds.columns_meta[col]['style'], css_classes=['wdgkey-meta_style_'+col, 'meta-drop'])
+            topwdg['meta_style_'+col] = bmw.TextInput(title='"'+col+ '" Style', value=reeds.columns_meta[col]['style'], css_classes=['wdgkey-meta_style_'+col, 'meta-drop'], visible=False)
 
     #Filter Scenarios widgets and Result widget
     scenarios = []
@@ -200,19 +200,21 @@ def get_wdg_reeds(path, init_load, wdg_config, wdg_defaults, custom_sorts, custo
     if scenarios:
         labels = [a['name'] for a in scenarios]
         topwdg['scenario_filter_dropdown'] = bmw.Div(text='Filter Scenarios', css_classes=['scenario-filter-dropdown'])
-        topwdg['scenario_filter'] = bmw.CheckboxGroup(labels=labels, active=list(range(len(labels))), css_classes=['wdgkey-scenario_filter'])
+        topwdg['scenario_filter_sel_all'] = bmw.Button(label='Select All', button_type='success', css_classes=['scenario-filter-drop','select-all-none'], visible=False)
+        topwdg['scenario_filter_sel_none'] = bmw.Button(label='Select None', button_type='success', css_classes=['scenario-filter-drop','select-all-none'], visible=False)
+        topwdg['scenario_filter'] = bmw.CheckboxGroup(labels=labels, active=list(range(len(labels))), css_classes=['scenario-filter-drop'], visible=False)
         #Add code to build report
         options = [o for o in os.listdir(this_dir_path+'/reports/templates'+GLRD['report_subdir']) if o.endswith(".py")]
         options = ['custom'] + options
         scenario_names = [i['name'] for i in scenarios]
         topwdg['report_dropdown'] = bmw.Div(text='Build Report', css_classes=['report-dropdown'])
-        topwdg['report_options'] = bmw.Select(title='Report', value=options[0], options=options, css_classes=['report-drop'])
-        topwdg['report_custom'] = bmw.TextInput(title='If custom, enter path to file', value='', css_classes=['report-drop'])
-        topwdg['report_diff'] = bmw.Select(title='Add Differences', value='No', options=['No','Yes','Base + Diff','Diff Only'], css_classes=['report-drop'])
-        topwdg['report_base'] = bmw.Select(title='Base Case For Differences', value=scenario_names[0], options=scenario_names, css_classes=['report-drop'])
-        topwdg['report_debug'] = bmw.Select(title='Debug Mode', value='No', options=['Yes','No'], css_classes=['report-drop'])
-        topwdg['report_build'] = bmw.Button(label='Build Report', button_type='success', css_classes=['report-drop'])
-        topwdg['report_build_separate'] = bmw.Button(label='Build Separate Reports', button_type='success', css_classes=['report-drop'])
+        topwdg['report_options'] = bmw.Select(title='Report', value=options[0], options=options, css_classes=['report-drop'], visible=False)
+        topwdg['report_custom'] = bmw.TextInput(title='If custom, enter path to file', value='', css_classes=['report-drop'], visible=False)
+        topwdg['report_diff'] = bmw.Select(title='Add Differences', value='No', options=['No','Yes','Base + Diff','Diff Only'], css_classes=['report-drop'], visible=False)
+        topwdg['report_base'] = bmw.Select(title='Base Case For Differences', value=scenario_names[0], options=scenario_names, css_classes=['report-drop'], visible=False)
+        topwdg['report_debug'] = bmw.Select(title='Debug Mode', value='No', options=['Yes','No'], css_classes=['report-drop'], visible=False)
+        topwdg['report_build'] = bmw.Button(label='Build Report', button_type='success', css_classes=['report-drop'], visible=False)
+        topwdg['report_build_separate'] = bmw.Button(label='Build Separate Reports', button_type='success', css_classes=['report-drop'], visible=False)
 
         topwdg['result'] = bmw.Select(title='Result', value='None', options=['None']+list(reeds.results_meta.keys()), css_classes=['wdgkey-result'])
     #save defaults
@@ -226,11 +228,19 @@ def get_wdg_reeds(path, init_load, wdg_config, wdg_defaults, custom_sorts, custo
             topwdg[key].on_change('value', update_reeds_meta)
         elif key.startswith('var_'):
             topwdg[key].on_change('value', update_reeds_var)
+    topwdg['scenario_filter_sel_all'].on_click(scenario_filter_select_all)
+    topwdg['scenario_filter_sel_none'].on_click(scenario_filter_select_none)
     topwdg['report_build'].on_click(build_reeds_report)
     topwdg['report_build_separate'].on_click(build_reeds_report_separate)
     topwdg['result'].on_change('value', update_reeds_result)
     print('***Done fetching ReEDS scenarios.')
     return (topwdg, scenarios)
+
+def scenario_filter_select_all():
+    core.GL['widgets']['scenario_filter'].active = list(range(len(core.GL['widgets']['scenario_filter'].labels)))
+
+def scenario_filter_select_none():
+    core.GL['widgets']['scenario_filter'].active = []
 
 def get_reeds_data(topwdg, scenarios, result_dfs):
     '''

--- a/bokehpivot/templates/scripts.js
+++ b/bokehpivot/templates/scripts.js
@@ -12,7 +12,12 @@ $(document).ready(function(){
         $(this).next().toggle();
     });
     $('body').on('click', '.scenario-filter-dropdown', function(){
-        $('.wdgkey-scenario_filter').toggle();
+        $('.scenario-filter-drop').toggle();
+    });
+    $('body').on('click', '.filter-head', function(){
+        $(this).next().toggle();
+        $(this).next().next().toggle();
+        $(this).next().next().next().toggle();
     });
     $('body').on('click', '.report-dropdown', function(){
         $('.report-drop').toggle();
@@ -47,30 +52,13 @@ $(document).ready(function(){
     $('body').on('click', '.filters-dropdown', function(){
         $('.filter-head').toggle();
         $('.filters-update').toggle();
-        $('.select-all-none').hide();
-        $('.filter').hide();
-    });
-    $('body').on('click', '.filter-head, .scenario-filter-dropdown', function(){
-        if($(this).next('.select-all-none').length == 0){
-            $(this).after('<div class="select-all-none"><span class="select-all select-opt">All</span>|<span class="select-none select-opt">None</span>');
-        }else{
-            $(this).next(".select-all-none").toggle();
-        }
-    });
-    $('body').on('click', '.filter-head', function(){
-        $(this).next(".select-all-none").next(".filter").toggle();
+        $('.filter-drop').hide();
     });
     $('body').on('click', '.adjust-dropdown', function(){
         $('.adjust-drop').toggle();
     });
     $('body').on('click', '.map-dropdown', function(){
         $('.map-drop').toggle();
-    });
-    $('body').on('click', '.select-opt', function(){
-        var checked_bool = $(this).hasClass('select-all') ? true: false;
-        $(this).parent().next('.bk-widget').find('.bk-bs-checkbox input').prop( "checked", checked_bool);
-        $(this).parent().next('.bk-widget').find('.bk-bs-checkbox input').first().click();
-        $(this).parent().next('.bk-widget').find('.bk-bs-checkbox input').first().click();
     });
 });
 //pressing Alt key will collapse menus.
@@ -84,7 +72,7 @@ document.onkeydown = function(e) {
     $('.wdgkey-result select').hide();
     $('.wdgkey-presets select').hide();
     $('.chart-drop').hide();
-    $('.wdgkey-scenario_filter').hide();
+    $('.scenario-filter-drop').hide();
     $('.x-drop').hide();
     $('.y-drop').hide();
     $('.legend-drop').hide();
@@ -93,8 +81,7 @@ document.onkeydown = function(e) {
     $('.adv-drop').hide();
     $('.filter-head').hide();
     $('.filters-update').hide();
-    $('.select-all-none').hide();
-    $('.filter').hide();
+    $('.filter-drop').hide();
     $('.adjust-drop').hide();
     $('.map-drop').hide();
     $('.update-drop').hide();

--- a/bokehpivot/templates/styles.css
+++ b/bokehpivot/templates/styles.css
@@ -25,40 +25,38 @@ body {
     width: 225px !important;
     height: auto !important;
     overflow-y: scroll !important;
+    padding: 5px !important;
+}
+.widgets_section > div{
+    position: relative !important;
+    top: 0px !important;
+    right: 0px !important;
+    bottom: 0px !important;
+    left: 0px !important;
+    height: auto !important;
+    width: auto !important;
+    margin-top: 10px !important;
 }
 .plots_section{
+    position: static !important;
     margin-left: 250px !important;
     width: auto !important;
     height: auto !important;
     display: inline-block !important;
     flex-shrink: 1 !important;
 }
-.bk-plot-layout{
+.plots_section > div{
+    position: relative !important;
+    top: 0px !important;
+    right: 0px !important;
+    bottom: 0px !important;
+    left: 0px !important;
     display: inline-block !important;
-}
-.chart-drop,
-.reeds-vars-drop,
-.meta-drop,
-.report-drop,
-.x-drop,
-.y-drop,
-.series-drop,
-.explode-drop,
-.adv-drop,
-.filter,
-.filters-update,
-.adjust-drop,
-.map-drop,
-.wdgkey-scenario_filter,
-.update-drop,
-.download-drop{
-    display: none;
 }
 .filter-head{
     font-weight: bold;
     cursor: pointer;
     color: purple;
-    display: none;
 }
 .chart-dropdown,
 .data-dropdown,
@@ -90,12 +88,6 @@ body {
     cursor: pointer;
     text-decoration: underline;
 }
-.select-opt{
-    color: blue;
-    cursor: pointer;
-    margin-left: 5px;
-    margin-right: 5px;
-}
 .legend-drop{
     border: 1px solid lightgrey;
     padding: 10px;
@@ -115,4 +107,8 @@ body {
 }
 .config-display-key{
     font-weight: bold;
+}
+.bk.select-all-none{
+    display: inline-block;
+    margin-right:5px;
 }


### PR DESCRIPTION
This update does these things:

1. Fixes styling issues and html download bug in bokehpivot interface when using the latest bokeh version
1. Allows compatibility with unix-like systems (e.g. Macs)
1. Adds map arrow locations
1. Fixes error when report directory already exists: The existing report is renamed with a timestamp to archive it.