### PR TITLE
Shrink the size of runs using cases_small

### DIFF
--- a/b_inputs.gms
+++ b/b_inputs.gms
@@ -2331,11 +2331,11 @@ $endif.ofswindban
 
 * turn off first 5 onshore wind technologies
 $ifthene.onswindban %GSw_OnsWind6to10% == 0
-bannew('wind-ons_6') = yes ;
-bannew('wind-ons_7') = yes ;
-bannew('wind-ons_8') = yes ;
-bannew('wind-ons_9') = yes ;
-bannew('wind-ons_10') = yes ;
+ban('wind-ons_6') = yes ;
+ban('wind-ons_7') = yes ;
+ban('wind-ons_8') = yes ;
+ban('wind-ons_9') = yes ;
+ban('wind-ons_10') = yes ;
 $endif.onswindban
 
 * turn off biopower technology

--- a/cases_small.csv
+++ b/cases_small.csv
@@ -3,10 +3,13 @@ timetype,seq
 endyear,2030
 GSw_RegionLevel,interconnect
 GSw_Region,texas
+GSw_AggregateRegions,1
+GSw_AugurCurtailment,0
 GSw_BanRECT,1
 GSw_BatteryMandate,0
 GSw_Biopower,0
 GSw_CCS,0
+GSw_CO2_Detail,0
 GSw_CoalIGCC,0
 GSw_CoalNew,0
 GSw_CofireNew,0
@@ -27,6 +30,7 @@ GSw_OfsWind,0
 GSw_OnsWind6to10,0
 GSw_OpRes,0
 GSw_PVB,0
+GSw_RECT,0
 GSw_Refurb,0
 GSw_ReserveMargin,0
 GSw_Retire,0
@@ -35,6 +39,7 @@ GSw_SkipAugurYear,2030
 GSw_StateCap,0
 GSw_StateRPS,0
 GSw_Storage,0
+GSw_TransIntraCost,0
 GSw_TransMultiLink,0
 GSw_Upgrades,0
 ivt_suffix,small

--- a/inputs/userinput/aggregate_region_files.csv
+++ b/inputs/userinput/aggregate_region_files.csv
@@ -182,7 +182,7 @@ poi_cap_init.csv,.csv,0,sum,*rb,,0,0,,done
 prescribed_nonRSC.csv,.csv,0,sum,r,"t,i",0,0,,done
 prescribed_rsc.csv,.csv,0,sum,r,"t,i",0,0,,done
 prm_annual.csv,.csv,1,,,*nercr,0,0,,done
-ptc_unit_value.csv,.csv,1,mean,,"*i,v,t",0,0,,done
+ptc_value_scaled.csv,.csv,1,mean,,"*i,v,t",0,0,,done
 ptc_values.csv,.csv,1,mean,,"i,v,t,wide",1,0,,only for retail
 pv_cf_improve.csv,.csv,1,,,,0,,,done
 pv_frac_of_depreciation.csv,.csv,1,,,,9999,0,,done
@@ -252,7 +252,8 @@ transmission_line_fom.csv,.csv,0,trans_lookup,"*r,rr",trtype,0,0,drop_dup_r,done
 transmission_vsc_routes.csv,.csv,1,,,,9999,0,,handled in transmission_multilink.py
 transmission_vsc_regions.csv,.csv,1,,,,9999,0,,handled in transmission_multilink.py
 unapp_water_sea_distr.csv,.csv,0,mean,r,"wst,wide",1,0,,done
-unbundled_limit.csv,.csv,1,,,,9999,0,,done
+unbundled_limit_ces.csv,.csv,1,,,,9999,0,,done
+unbundled_limit_rps.csv,.csv,1,,,,9999,0,,done
 upgrade_costs_ccs_coal.csv,.csv,1,,,,9999,0,,done
 upgrade_costs_ccs_gas.csv,.csv,1,,,,9999,0,,done
 upgrade_link.csv,.csv,1,,,,9999,0,,done


### PR DESCRIPTION
Runs completed using cases_small.csv were designed to result in model runs that were below the limit of 5,000 rows and columns for a trial GAMS license.  Changes to the model over the past year have made runs using cases_small much larger, exceeding the 5,000 limit.  This pull request utilizes the capability to aggregate regions to turn cases_small into a single-region representation of ERCOT, allowing model size to remain below the 5,000 limit.  Running the model using other cases files should not be impacted.