### PR TITLE
fix: Update geopandas version to fix error with fiona

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -43,7 +43,7 @@ dependencies:
     ### vvv be excluded if you're having trouble building the environment.
     - cmocean==3.0.3 # for more plotting colors
     - folium==0.14.0 # for interactive maps
-    - geopandas==0.14.0 # for region aggregation and plotting maps
+    - geopandas==1.0.1 # for region aggregation and plotting maps
     - proj==0.2.0 # for plotting maps
     - pyproj==3.6.1 # for plotting maps
     - python-pptx==0.6.22 # for postprocessing/compare_cases.py


### PR DESCRIPTION
## Summary
I followed all the instructions on the [setup](https://nrel.github.io/ReEDS-2.0/setup.html) page, and this was the only obstacle preventing the model from running.

## Technical Details
### Implementation notes

The error I was hitting was this:
```
Starting the run for case test_ercot_small
Running test_ercot_small
----------------------
starting copy_files.py
----------------------
copy_files.py | 2024-09-26 21:17:30 | INFO | Starting copy_files.py
copy_files.py | 2024-09-26 21:17:30 | INFO | Copying non-region-indexed files
copy_files.py | 2024-09-26 21:17:30 | ERROR | Traceback (most recent call last):
copy_files.py | 2024-09-26 21:17:30 | ERROR |   File "/Users/david/code/ReEDS-2.0/runs/test_ercot_small/input_processing/copy_files.py", line 655, in <module>
copy_files.py | 2024-09-26 21:17:30 | ERROR | dfmap = reedsplots.get_dfmap(os.path.join(inputs_case,'..'))
copy_files.py | 2024-09-26 21:17:30 | ERROR |   File "/Users/david/code/ReEDS-2.0/postprocessing/reedsplots.py", line 142, in get_dfmap
copy_files.py | 2024-09-26 21:17:30 | ERROR | dfba = get_zonemap(case)
copy_files.py | 2024-09-26 21:17:30 | ERROR |   File "/Users/david/code/ReEDS-2.0/postprocessing/reedsplots.py", line 78, in get_zonemap
copy_files.py | 2024-09-26 21:17:30 | ERROR | gpd.read_file(os.path.join(reeds_path,'inputs','shapefiles','US_PCA'))
copy_files.py | 2024-09-26 21:17:30 | ERROR |   File "/opt/anaconda3/envs/reeds2/lib/python3.11/site-packages/geopandas/io/file.py", line 297, in _read_file
copy_files.py | 2024-09-26 21:17:30 | ERROR | return _read_file_fiona(
copy_files.py | 2024-09-26 21:17:30 | ERROR |   File "/opt/anaconda3/envs/reeds2/lib/python3.11/site-packages/geopandas/io/file.py", line 315, in _read_file_fiona
copy_files.py | 2024-09-26 21:17:30 | ERROR | if _is_zip(str(path_or_bytes)):
copy_files.py | 2024-09-26 21:17:30 | ERROR |   File "/opt/anaconda3/envs/reeds2/lib/python3.11/site-packages/geopandas/io/file.py", line 173, in _is_zip
copy_files.py | 2024-09-26 21:17:30 | ERROR | parsed = fiona.path.ParsedPath.from_uri(path)
copy_files.py | 2024-09-26 21:17:30 | ERROR | AttributeError
copy_files.py | 2024-09-26 21:17:30 | ERROR | :
copy_files.py | 2024-09-26 21:17:30 | ERROR | module 'fiona' has no attribute 'path'
copy_files.py | 2024-09-26 21:17:30 | ERROR | . Did you mean: '
copy_files.py | 2024-09-26 21:17:30 | ERROR | Path
copy_files.py | 2024-09-26 21:17:30 | ERROR | '?
```

This was a [known issue with the old version of geopandas](https://github.com/geopandas/geopandas/issues/3390). Updating to `1.0.1` fixes the issue, but it's possible it might break something somewhere else, I couldn't really tell, but I figured having a note about how someone might get past this themselves is good for posterity, even if you just want to close the PR.
