### PR TITLE
Remove hardcoded path in reeds2.py

### DIFF
--- a/postprocessing/bokehpivot/reeds2.py
+++ b/postprocessing/bokehpivot/reeds2.py
@@ -33,7 +33,7 @@ prod_techs = h2_techs + ['dac']
 niche_techs =  ['hydro','csp','geothermal','beccs','lfill-gas','biopower']
 price_types = ['load','res_marg','oper_res','state_rps','nat_gen']
 ccs_techs = ['gas-cc-ccs_mod_upgrade','coal-ccs_mod_upgrade','gas-cc-ccs_max_upgrade','coal-ccs_max_upgrade','gas-cc-ccs_mod','gas-cc-ccs_max','coal-ccs_mod','coal-ccs_max','coal-ccs-nsp','coal-ccs-flex','gas-cc-ccs-flex']
-water_techs = pd.read_csv('/Users/jcarag/ReEDS/PSH_Updates/ReEDS-2.0/postprocessing/bokehpivot/in/reeds2/tech_ctt_wst.csv')['tech'].tolist()
+water_techs = pd.read_csv(os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, 'postprocessing/bokehpivot/in/reeds2/tech_ctt_wst.csv')))['tech'].tolist()
 water_techs = [x.lower() for x in water_techs]
 
 #1. Preprocess functions for results_meta


### PR DESCRIPTION
## Summary
Removes the hardcoded path in reeds2.py. This should fix the broken bokeh reports.


## Technical Details
### Implementation notes

### Additional changes (if any)

### Switches added/removed/changed (if any)

### Issues resolved (if any)

### Known incompatibilities (if any)

### Relevant sources or documentation (if any)

### Is the model cleaner/better/faster/smaller than before? If so, how?

## Validation / Comparison Report
### Link to report and/or example plots

### (if pertinent) How big is the default run folder (runs/{base}_ref_seq/) before and after the change?

### (if pertinent) What is the run time for ref_seq on the same machine before and after the change?