### PR TITLE
Remove Julia from environment.yml file

### DIFF
--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -86,31 +86,6 @@ It is highly recommended to run ReEDS using the conda environment provided in th
 conda env create -f environment.yml
 ```
 
-**IMPORTANT** : Conda does not currently support `julia` for Windows systems. Running the above command will yield the error:
-
-```bash
-Channels:
- - defaults
- - conda-forge
-Platform: win-64
-Collecting package metadata (repodata.json): done
-Solving environment: failed
-
-PackagesNotFoundError: The following packages are not available from current channels:
-
-  - julia=1.8*
-```
-
-This error may be resolved by opening the `environment.yml` file in a text editor such as Notepad or VSCode, and adding a pound sign as the first character in the line containing `- julia=`. 
-
-The update should look like:
-
-```bash
-# - julia=1.8 # for PRAS and stress periods
-```
-
-Save the changes and rerun the command as intended. Instructions to install Julia on Windows are below in section [ReEDS2PRAS, julia, and stress periods setup](##ReEDS2PRAS,-julia,-and-stress-periods-setup).
-
 You can verify that the environment was successfully created using the following (you should see `reeds2` in the list):
 
 ```
@@ -232,7 +207,13 @@ git lfs install
 ## ReEDS2PRAS, julia, and stress periods setup
 Since ReEDS uses stress periods by default, julia will need to be installed and set up to run the model. To get julia and stress periods set up: 
 1. Install Julia. There are different procedures for mac/linux and windows.
-    1. [mac/linux]: Julia is included in the conda environment so you should be all set.
+    1. [mac/linux]: After installing the `reeds2` environment, execute the following commands.
+
+   ```bash
+   $ conda activate reeds2
+   (reeds2) $ conda install "julia>=1.8"
+   ```
+
     2. [windows]: Install Julia from [https://julialang.org/downloads/](https://julialang.org/downloads/).
 2. From the ReEDS-2.0 directory, run `julia --project=. instantiate.jl`
 
@@ -243,7 +224,6 @@ When setting up julia on Windows, you may run into some issues when running `jul
 1. Manually install [Random123](https://github.com/JuliaRandom/Random123.jl) 
 
 2. Re-run `julia --project=. instantiate.jl`
-
 
 
 If that doesn't resolve the issue, the following may help: 

--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -86,6 +86,31 @@ It is highly recommended to run ReEDS using the conda environment provided in th
 conda env create -f environment.yml
 ```
 
+**IMPORTANT** : Conda does not currently support `julia` for Windows systems. Running the above command will yield the error:
+
+```bash
+Channels:
+ - defaults
+ - conda-forge
+Platform: win-64
+Collecting package metadata (repodata.json): done
+Solving environment: failed
+
+PackagesNotFoundError: The following packages are not available from current channels:
+
+  - julia=1.8*
+```
+
+This error may be resolved by opening the `environment.yml` file in a text editor such as Notepad or VSCode, and adding a pound sign as the first character in the line containing `- julia=`. 
+
+The update should look like:
+
+```bash
+# - julia=1.8 # for PRAS and stress periods
+```
+
+Save the changes and rerun the command as intended. Instructions to install Julia on Windows are below in section [ReEDS2PRAS, julia, and stress periods setup](##ReEDS2PRAS,-julia,-and-stress-periods-setup).
+
 You can verify that the environment was successfully created using the following (you should see `reeds2` in the list):
 
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -19,11 +19,6 @@ dependencies:
   - gitpython=3.1 # for complete run metadata
   - ipykernel=6.25 # for interactive python in VS Code
   - ipywidgets=8.0 # for jupyter notebooks
-  ## vvv Keep julia here if you're installing on the HPC.
-  ## vvv If you're installing on a local machine, it's suggested to comment out
-  ## vvv julia and install directly from https://julialang.org/downloads/.
-  ## vvv If you're on Windows, you MUST comment out julia and install directly.
-  - julia=1.8 # for PRAS and stress periods
   ## ^^^
   - mapclassify=2.5 # more mapping tools
   - matplotlib=3.7 # for plots


### PR DESCRIPTION
I couldn't find a guide for contributors, so I hope this is okay. This PR contains no new features but will provide users with a more consistent experience across platforms. 

## Summary
This PR changes the default environment setup by removing the Julia installation from the `environment.yml` file. I also updated the section for installing PRAS on Linxu/Mac to install Julia via conda. This change was motivated by Issue #169 and my own experience installing ReEDS with the current documentation. 

This change provides the following benefits:

1. A consistent user experience. Since `PRAS` is optional, Julia should be optional for users on all platforms.
2. ReEDS installation can now be automated on Windows machines, where before it was impossible (or prohibitively difficult).
3. Retains the ability for a single line installation on Unix machines.

```bash
conda env create -f environment.yml; conda activate reeds2; conda install -y "julia>=1.8"
```
4. Reduces additional documentation. My original fix for this was to add instructions to `setup.md` in the Windows section. This approach is much more streamlined.
 
## Technical Details
### Issues resolved (if any)

Closes #169 

### Known incompatibilities (if any)

None

### Relevant sources or documentation (if any)

Per this [stackoverflow](https://stackoverflow.com/questions/75865826/install-julia-in-anaconda) post, Julia is not available on Windows via Conda. It is not clear when this will be changed, if ever.