### PR TITLE
Fix bug with "historic" switch

### DIFF
--- a/runbatch.py
+++ b/runbatch.py
@@ -338,7 +338,7 @@ def check_compatibility(sw):
 
     ### Compatible switch combinations 
     if sw['GSw_EFS1_AllYearLoad'] == 'historic' :
-        if ('demand_' + sw['demandscen'] +'.csv') in os.listdir(os.path.join(reeds_path, 'inputs','load')) :
+        if ('demand_' + sw['demandscen'] +'.csv') not in os.listdir(os.path.join(reeds_path, 'inputs','load')) :
             raise ValueError("The demand file specified by the demandscen switch is not in the inputs/load folder")
 
     if sw['GSw_PRM_scenario'] == 'none':


### PR DESCRIPTION
## Summary
This addresses the following error: [Error with implementation of 'historic' switch in runbatch.py](https://github.com/NREL/ReEDS-2.0/issues/196)


## Technical Details
### Implementation notes

### Additional changes (if any)

### Switches added/removed/changed (if any)

### Issues resolved (if any)

### Known incompatibilities (if any)

### Relevant sources or documentation (if any)

### Is the model cleaner/better/faster/smaller than before? If so, how?

## Validation / Comparison Report
### Link to report and/or example plots

### (if pertinent) How big is the default run folder (runs/{base}_ref_seq/) before and after the change?

### (if pertinent) What is the run time for ref_seq on the same machine before and after the change?