### PR TITLE
Correct CITATION.cff for Zenodo

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -60,7 +60,6 @@ authors:
     family-names: Turan
   - given-names: Max
     family-names: Vanatta
-  - {}
 url: 'https://www.nrel.gov/analysis/reeds/index.html'
 abstract: >-
   The Regional Energy Deployment System (ReEDS) is


### PR DESCRIPTION
## Summary
This PR updates the `CITATION.cff` file to fix a metadata error that prevented Zenodo from completing the upload when creating a release.

Removed an invalid creator entry that caused Zenodo to fail with "Family name cannot be blank.' This change ensures that future releases (starting with v2025.5.1) will successfully generate a DOI in Zenodo.

There are no code changes.