### PR TITLE
first attempt at fixing the file not found error for county profiles

### DIFF
--- a/input_processing/copy_files.py
+++ b/input_processing/copy_files.py
@@ -18,6 +18,8 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import reeds
 
 
+
+
 #%% ===========================================================================
 ### --- General Read Functions---
 ### ===========================================================================
@@ -1165,7 +1167,11 @@ def write_county_vre_hourly_profiles(inputs_case, reeds_path):
     present_in_fv = 0
     file_version_updates = 0
     missing_file_versions = []
+    # github runner test settings
+    # tries to get environment variable from github, if it's not found it defaults to False
+    github_test = os.getenv("GITHUB_COUNTY_TEST", False)
     for i,row in profile_data.iterrows():
+        techlabel = f"{row.tech}{'_radial' if row.tech == 'wind-ofs' else ''}"
         # If the profile is already present, do nothing
         if row['present'] is True:
             present_in_fv += 1
@@ -1186,14 +1192,8 @@ def write_county_vre_hourly_profiles(inputs_case, reeds_path):
             access_case = row['access_case']
             # If NLR user, then attempt to copy data from the remote location defined in
             # rev_paths.csv.
-
-            # github runner test settings
-            # tries to get environment variable from github, if it's not found it defaults to False
-            github_test = os.getenv("GITHUB_COUNTY_TEST", False)
-
             if 'github.nrel.gov' in remote_url:
                 sc_path = row['sc_path']
-                techlabel = f"{row.tech}{'_radial' if row.tech == 'wind-ofs' else ''}"
                 print(f'Copying county-level hourly profiles for {techlabel} {row["access_case"]}')
 
                 if github_test:
@@ -1244,15 +1244,27 @@ def write_county_vre_hourly_profiles(inputs_case, reeds_path):
                     file_version_new = pd.concat([file_version_new, newrow])
                 file_version_updates += 1
 
-            # If non-NLR user, then save the name of the missing file, and write it out
+            # If non-NLR user, CHECK IF THE FILES EXISTS then save the name of the missing file, and write it out
             # in the error message below
             else:
-                missing_file_versions.append(f'{row["tech"]}-{access_case}_county.h5')
+                # expected file path
+                fpath = os.path.join(
+                        reeds_path,'inputs','variability','multi_year',
+                        f'{techlabel}-{access_case}_county.h5',
+                    )
+                if os.path.exists(fpath):
+                    continue
+                else:
+                    print(
+                        f"File not found at {fpath}.\n"
+                    )
+                    missing_file_versions.append(f'{row["tech"]}-{access_case}_county.h5')
+
     # If any county-level file is missing from the inputs folder but a file_version.csv exists,
     # then print out an error message to delete the file_version.csv and restart the run
     if (existing_fv) and (present_in_fv < 1):
         error = ("It appears that there is a file_version.csv present in\n"
-            "/inputs/variability/multi-year/ despite a county-level file(s) missing\n"
+            "/inputs/variability/multi_year/ despite a county-level file(s) missing\n"
             "from the folder. Delete file_version.csv from the folder and restart the run\n"
             "to have ReEDS redownload the missing county-level file(s)."
         )
@@ -1261,7 +1273,7 @@ def write_county_vre_hourly_profiles(inputs_case, reeds_path):
     # file names and where to download them
     if len(missing_file_versions) > 0:
         error = ("To run ReEDS at county-level spatial resolution, please download the following\n"
-            "county-level data files from OpenEI to /inputs/variability/multi-year/\n\n"
+            "county-level data files from OpenEI to /inputs/variability/multi_year/\n\n"
             "Files:\n"
             +"\n".join(missing_file_versions)+"\n\n"
             +"OpenEI files link:\n"


### PR DESCRIPTION
## Summary

In order to run the current version of ReEDS with a county-level spatial resolution, users are instructed to download files from OpenEI to the folder `inputs/variability/multi_year` on their machines. However, ReEDS does not recognize that these files exist at all after following these steps. The error message to download the files from OpenEI persists.

The main issues (from issue #261): 

1. `write_county_vre_hourly_profiles` never checks the local installation for the expected files. Non-NLR users are railroaded to the error message about downloading the files from OpenEI.
2. The data repository on [OpenEI ](https://data.openei.org/submissions/5986) that users are directed to appears outdated. It does not include any files for `distpv`. Here is a [newer repository ](https://data.openei.org/submissions/8379) that DOES include `distpv`.
3. Extracting the offshore wind data yields a `wind-ofs-reference_county.h5` file (and other access cases), but the function to copy this file expects it to follow the pattern: `wind-ofs_radial-reference_county.h5`. Which the BA files that ship with ReEDS do follow. 
4. Even the new dataset from OpenEI does not include a `dist-pv-reference_county.h5` only a `dist-pv-none_county.h5` file. However, the access case in `revData` for `distpv` is listed as "None" so I'm not sure what the solution, here is.

## Technical Details
### Implementation notes

Instead of immediately adding the file to a "missing_cases" list, the `write_county_vre_hourly_profiles` function now checks if the files exist at the expected location. If it does not exist, then the file is appended.

### Additional changes (if any)

I also made some modest changes including

1. I moved the `github_test` variable outside of the for-loop because it is a static variable that will never change.
2. I changed references to a `multi-year` folder to `multi_year` since the former does not actually exist (though I did try moving the files to a `multi-year` folder to see if that would work, and, surprise surprise, it did not). 

Additionally, I had to update filenames for wind-ofs and distv from the most recent OpenEI repository. 

`wind-ofs-reference` --> `wind-ofs_radial-reference`
`dist-pv-none` --> `dist-pv-reference`

Once those pass, the run continues.

### Switches added/removed/changed (if any)

### Issues resolved (if any)
This pull request closes #261.

### Known incompatibilities (if any)

The errors identified in issue #261 are resolved, but there is a new error message later on in the `copy_files` script.

```bash
copy_files.py | 2026-03-26 16:36:27 | INFO | ...copying transmission_capacity_init_AC_r.csv
copy_files.py | 2026-03-26 16:36:27 | ERROR | Traceback (most recent call last):
copy_files.py | 2026-03-26 16:36:27 | ERROR |   File "/home/ce-admin/research/ReEDS-2.0/runs/TEST2026_Mid_Case_LA/input_processing/copy_files.py", line 1927, in <module>
copy_files.py | 2026-03-26 16:36:27 | ERROR | main(reeds_path, inputs_case)
copy_files.py | 2026-03-26 16:36:27 | ERROR |   File "/home/ce-admin/research/ReEDS-2.0/runs/TEST2026_Mid_Case_LA/input_processing/copy_files.py", line 1871, in main
copy_files.py | 2026-03-26 16:36:27 | ERROR | write_region_indexed_files(
copy_files.py | 2026-03-26 16:36:27 | ERROR |   File "/home/ce-admin/research/ReEDS-2.0/runs/TEST2026_Mid_Case_LA/input_processing/copy_files.py", line 1535, in write_region_indexed_files
copy_files.py | 2026-03-26 16:36:27 | ERROR | df = subset_to_valid_regions(
copy_files.py | 2026-03-26 16:36:27 | ERROR |   File "/home/ce-admin/research/ReEDS-2.0/runs/TEST2026_Mid_Case_LA/input_processing/copy_files.py", line 723, in subset_to_valid_regions
copy_files.py | 2026-03-26 16:36:27 | ERROR | df_county.loc[idx, tx_region_col] = agglevel_variables['BA_2_county'][df_county.loc[idx,tx_region_col]]
...
copy_files.py | 2026-03-26 16:36:27 | ERROR | ~
copy_files.py | 2026-03-26 16:36:27 | ERROR | ~
copy_files.py | 2026-03-26 16:36:27 | ERROR | KeyError
copy_files.py | 2026-03-26 16:36:27 | ERROR | :
copy_files.py | 2026-03-26 16:36:27 | ERROR | 'p05001'
```

So, something else is possibly wrong with the files or the function itself is wrong. More investigation is necessary.

### Relevant sources or documentation (if any)

### Is the model cleaner/better/faster/smaller than before? If so, how?

## Validation / Comparison Report
### Link to report and/or example plots

### (if pertinent) How big is the default run folder (runs/{base}_ref_seq/) before and after the change?

### (if pertinent) What is the run time for ref_seq on the same machine before and after the change?